### PR TITLE
Show error if the scanned file is not a valid PHP script.

### DIFF
--- a/src/PhpunitMerger/Command/CoverageCommand.php
+++ b/src/PhpunitMerger/Command/CoverageCommand.php
@@ -1,7 +1,6 @@
 <?php
 namespace Nimut\PhpunitMerger\Command;
 
-use Exception;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover;
 use SebastianBergmann\CodeCoverage\Report\Html\Facade;
@@ -46,8 +45,8 @@ class CoverageCommand extends Command
 
         foreach ($finder as $file) {
             $coverage = require $file->getRealPath();
-            if (!get_class($coverage) === CodeCoverage::class) {
-                throw new Exception($file->getRealPath() . ' does not return a ' . CodeCoverage::class . ' class!');
+            if (!$coverage instanceof CodeCoverage) {
+                throw new \RuntimeException($file->getRealPath() . ' doesn\'t return a valid ' . CodeCoverage::class . ' object!');
             }
             $codeCoverage->merge($coverage);
         }

--- a/src/PhpunitMerger/Command/CoverageCommand.php
+++ b/src/PhpunitMerger/Command/CoverageCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Nimut\PhpunitMerger\Command;
 
+use Exception;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover;
 use SebastianBergmann\CodeCoverage\Report\Html\Facade;
@@ -45,6 +46,9 @@ class CoverageCommand extends Command
 
         foreach ($finder as $file) {
             $coverage = require $file->getRealPath();
+            if (!get_class($coverage) === CodeCoverage::class) {
+                throw new Exception($file->getRealPath() . ' does not return a ' . CodeCoverage::class . ' class!');
+            }
             $codeCoverage->merge($coverage);
         }
 


### PR DESCRIPTION
In the first try i used xml Report files. It is documented that this is wrong, but this patch saves time.