### PR TITLE
Support for phpunit 9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,12 +59,16 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
+    - env: COVERAGE_VERSIONS="^5.0 ^6.0 ^7.0 ^8.0"
     - env: COVERAGE_VERSIONS="^5.0 ^6.0 ^7.0"
     - env: COVERAGE_VERSIONS="^5.0 ^6.0"
     - env: COVERAGE_VERSIONS="^5.0"
   include:
     - stage: test
       php: 7.4
+      env: COVERAGE_VERSIONS="~8.0.0"
+    - stage: test
+      php: 7.4
       env: COVERAGE_VERSIONS="~7.0.0"
     - stage: test
       php: 7.4
@@ -77,6 +81,9 @@ jobs:
       env: COVERAGE_VERSIONS="^5.0 ^6.0 ^7.0"
     - stage: test
       php: 7.3
+      env: COVERAGE_VERSIONS="~8.0.0"
+    - stage: test
+      php: 7.3
       env: COVERAGE_VERSIONS="~7.0.0"
     - stage: test
       php: 7.3
@@ -87,6 +94,9 @@ jobs:
     - stage: test
       php: 7.3
       env: COVERAGE_VERSIONS="^5.0 ^6.0 ^7.0"
+    - stage: test
+      php: 7.2
+      env: COVERAGE_VERSIONS="~8.0.0 ~8.1.0"
     - stage: test
       php: 7.2
       env: COVERAGE_VERSIONS="~7.0.0"
@@ -118,7 +128,7 @@ jobs:
     - stage: ✔ with sonarqube scanner
       if: type = push AND branch IN (master, pre-merge) AND env(SONAR_TOKEN) IS present AND fork = false
       php: 7.2
-      env: COVERAGE_VERSIONS="~5.0.0 ~5.1.0 ~5.2.0 ~5.3.0 ~6.0.0 ~6.1.0 ~7.0.0"
+      env: COVERAGE_VERSIONS="~5.0.0 ~5.1.0 ~5.2.0 ~5.3.0 ~6.0.0 ~6.1.0 ~7.0.0 ~8.0.0"
       before_install:
       before_script:
       script:

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "phpunit/php-code-coverage": ">=5.0 <8.0",
+        "phpunit/php-code-coverage": ">=5.0 <9.0",
         "symfony/console": ">=2.7 <6.0",
         "symfony/finder": ">=2.7 <6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.0 <9.0",
+        "phpunit/phpunit": ">=6.0 <10.0",
         "symfony/filesystem": ">=2.7 <6.0"
     },
     "suggest": {

--- a/tests/PhpunitMerger/Command/AbstractCommandTest.php
+++ b/tests/PhpunitMerger/Command/AbstractCommandTest.php
@@ -21,7 +21,7 @@ abstract class AbstractCommandTest extends TestCase
         $filesystem = new Filesystem();
         $filesystem->remove($this->logDirectory . $this->outputFile);
 
-        $this->assertFileNotExists($this->logDirectory . $this->outputFile);
+        $this->assertFileDoesNotExist($this->logDirectory . $this->outputFile);
     }
 
     public function assertOutputDirectoryNotExists()
@@ -29,6 +29,6 @@ abstract class AbstractCommandTest extends TestCase
         $filesystem = new Filesystem();
         $filesystem->remove($this->logDirectory . dirname($this->outputFile));
 
-        $this->assertDirectoryNotExists($this->logDirectory . dirname($this->outputFile));
+        $this->assertDirectoryDoesNotExist($this->logDirectory . dirname($this->outputFile));
     }
 }


### PR DESCRIPTION
I don't know why there is a direct constraint on the version of php-code-coverage and phpunit but I am creating this pull request so that the package can support other projects that want to use phpunit 9.x.