### PR TITLE
Adds options for lowUpperBound and highLowerBound for HTML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $ vendor/bin/phpunit-merger coverage <directory> [--html=<directory>] [<file>]
 **Options**
 
 - `html`: Directory where the HTML report should be stored 
+- `lowUpperBound`: (optional) The lowUpperBound value to be used for HTML format 
+- `highLowerBound`: (optional) The highLowerBound value to be used for HTML format 
 
 ### Log
 

--- a/src/PhpunitMerger/Command/CoverageCommand.php
+++ b/src/PhpunitMerger/Command/CoverageCommand.php
@@ -71,9 +71,9 @@ class CoverageCommand extends Command
         $this->writeCodeCoverage($codeCoverage, $output, $input->getArgument('file'));
         $html = $input->getOption('html');
         if ($html !== null) {
-            $lowUpperBound = $input->getOption('lowUpperBound') ?: 50;
-            $highLowerBound = $input->getOption('highLowerBound') ?: 90;
-            $this->writeHtmlReport($codeCoverage, $html, intval($lowUpperBound), intval($highLowerBound));
+            $lowUpperBound = (int)($input->getOption('lowUpperBound') ?: 50);
+            $highLowerBound = (int)($input->getOption('highLowerBound') ?: 90);
+            $this->writeHtmlReport($codeCoverage, $html, $lowUpperBound, $highLowerBound);
         }
 
         return 0;

--- a/src/PhpunitMerger/Command/CoverageCommand.php
+++ b/src/PhpunitMerger/Command/CoverageCommand.php
@@ -37,6 +37,18 @@ class CoverageCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'The directory where to write the code coverage report in HTML format'
+            )
+            ->addOption(
+                'lowUpperBound',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The lowUpperBound value to be used for HTML format'
+            )
+            ->addOption(
+                'highLowerBound',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The highLowerBound value to be used for HTML format'
             );
     }
 
@@ -59,7 +71,9 @@ class CoverageCommand extends Command
         $this->writeCodeCoverage($codeCoverage, $output, $input->getArgument('file'));
         $html = $input->getOption('html');
         if ($html !== null) {
-            $this->writeHtmlReport($codeCoverage, $html);
+            $lowUpperBound = $input->getOption('lowUpperBound') ?: 50;
+            $highLowerBound = $input->getOption('highLowerBound') ?: 90;
+            $this->writeHtmlReport($codeCoverage, $html, $lowUpperBound, $highLowerBound);
         }
 
         return 0;
@@ -86,9 +100,9 @@ class CoverageCommand extends Command
         }
     }
 
-    private function writeHtmlReport(CodeCoverage $codeCoverage, string $destination)
+    private function writeHtmlReport(CodeCoverage $codeCoverage, string $destination, int $lowUpperBound, int $highLowerBound)
     {
-        $writer = new Facade();
+        $writer = new Facade($lowUpperBound, $highLowerBound);
         $writer->process($codeCoverage, $destination);
     }
 }

--- a/src/PhpunitMerger/Command/CoverageCommand.php
+++ b/src/PhpunitMerger/Command/CoverageCommand.php
@@ -73,7 +73,7 @@ class CoverageCommand extends Command
         if ($html !== null) {
             $lowUpperBound = $input->getOption('lowUpperBound') ?: 50;
             $highLowerBound = $input->getOption('highLowerBound') ?: 90;
-            $this->writeHtmlReport($codeCoverage, $html, $lowUpperBound, $highLowerBound);
+            $this->writeHtmlReport($codeCoverage, $html, intval($lowUpperBound), intval($highLowerBound));
         }
 
         return 0;

--- a/tests/PhpunitMerger/Command/Coverage/CoverageCommandTest.php
+++ b/tests/PhpunitMerger/Command/Coverage/CoverageCommandTest.php
@@ -75,6 +75,29 @@ class CoverageCommandTest extends AbstractCommandTest
         $this->assertFileExists($this->logDirectory . $this->outputFile);
     }
 
+    public function testCoverageWritesHtmlReportWithCustomBounds()
+    {
+        $this->outputFile = 'html/index.html';
+        $this->assertOutputDirectoryNotExists();
+
+        $input = new ArgvInput(
+            [
+                'coverage',
+                $this->logDirectory . 'coverage/',
+                '--html=' . $this->logDirectory . dirname($this->outputFile),
+                '--lowUpperBound=20',
+                '--highLowerBound=70',
+            ]
+        );
+        $output = $this->prophesize(OutputInterface::class);
+        $output->write(Argument::type('string'))->shouldBeCalled();
+
+        $command = new CoverageCommand();
+        $command->run($input, $output->reveal());
+
+        $this->assertFileExists($this->logDirectory . $this->outputFile);
+    }
+
     public function testCoverageWritesOutputFileAndHtmlReport()
     {
         $this->outputFile = 'html/coverage.xml';

--- a/tests/PhpunitMerger/Command/Coverage/CoverageCommandTest.php
+++ b/tests/PhpunitMerger/Command/Coverage/CoverageCommandTest.php
@@ -96,6 +96,16 @@ class CoverageCommandTest extends AbstractCommandTest
         $command->run($input, $output->reveal());
 
         $this->assertFileExists($this->logDirectory . $this->outputFile);
+
+        $content = file_get_contents($this->logDirectory . $this->outputFile);
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('<strong>Low</strong>: 0% to 20%', $content);
+            $this->assertStringContainsString('<strong>High</strong>: 70% to 100%', $content);
+        } else {
+            // Fallback for phpunit < 7.0
+            $this->assertContains('<strong>Low</strong>: 0% to 20%', $content);
+            $this->assertContains('<strong>High</strong>: 70% to 100%', $content);
+        }
     }
 
     public function testCoverageWritesOutputFileAndHtmlReport()


### PR DESCRIPTION
- Adds these options to the command and passes them to the HTML writer
- Includes a new test that tests the processing of these options
- Includes the relevant changes to the readme

Fixes #14 