### PR TITLE
Fixed addTestSuites-Call in case the name attribute is empty and there is only one testsuite within the testsuite.

### DIFF
--- a/src/PhpunitMerger/Command/LogCommand.php
+++ b/src/PhpunitMerger/Command/LogCommand.php
@@ -82,7 +82,8 @@ class LogCommand extends Command
         foreach ($testSuites as $testSuite) {
             if (empty($testSuite['@attributes']['name'])) {
                 if (!empty($testSuite['testsuite'])) {
-                    $this->addTestSuites($parent, $testSuite['testsuite']);
+                    $children = isset($testSuite['testsuite']['@attributes']) ? [$testSuite['testsuite']] : $testSuite['testsuite'];
+                    $this->addTestSuites($parent, $children);
                 }
                 continue;
             }


### PR DESCRIPTION
We are using phpunit-merger to merge the result of named testsuites of phpunit. Handling of testsuites with only one testsuite as a child is already handled in case of subtestsuites. But was not handled correctly on the top level.