### PR TITLE
Combining junit files drops the file name

### DIFF
--- a/src/PhpunitMerger/Command/LogCommand.php
+++ b/src/PhpunitMerger/Command/LogCommand.php
@@ -95,7 +95,7 @@ class LogCommand extends Command
                 $element->setAttribute('parent', $parent->getAttribute('name'));
                 $attributes = $testSuite['@attributes'] ?? [];
                 foreach ($attributes as $key => $value) {
-                    $value = $key === 'name' ? $value : 0;
+                    $value = $key === 'name' || $key === 'file' ? $value : 0;
                     $element->setAttribute($key, (string)$value);
                 }
                 $parent->appendChild($element);


### PR DESCRIPTION
When using this in a project, the file attribute wasn't being combined properly, if I recall it was set to "0" instead of the proper value. This change seems to have fixed it for me.